### PR TITLE
Update hero and social blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1506,44 +1506,39 @@
     </section>
 
     <div class="social-media-bar">
-        <div class="social-media-container">
-            <a href="https://wa.me/6562750603" class="social-btn whatsapp-btn" target="_blank">
-                <i class="fab fa-whatsapp"></i> <span data-lang-key="socialWhatsapp">WhatsApp</span>
-            </a>
-            
-            <a href="https://shopee.sg/shop/62656629" class="social-btn shopee-btn" target="_blank">
-                <i class="fas fa-shopping-bag"></i> <span data-lang-key="socialShopee">Shopee</span>
-            </a>
-            
-            <a href="https://www.lazada.sg/shop/manly-food1627632387" class="social-btn lazada-btn" target="_blank">
-                <img src="https://img.icons8.com/color/48/000000/lazada.png" alt="Lazada Icon"> <span data-lang-key="socialLazada">Lazada</span>
-            </a>
-            
-            <a href="https://instagram.com/manlyfoodssg" class="social-btn instagram-btn" target="_blank">
-                <i class="fab fa-instagram"></i> <span data-lang-key="socialManlyFoods">MANLY FOODS IG</span>
-            </a>
-            
-            <a href="https://www.instagram.com/ahmadteasg/" class="social-btn ahmadtea-btn" target="_blank">
-                <i class="fab fa-instagram"></i> <span data-lang-key="socialAhmadTea">Ahmad Tea IG</span>
-            </a>
-            
-            <a href="https://www.tiktok.com/@manlyfoods" class="social-btn tiktok-btn" target="_blank">
-                <i class="fab fa-tiktok"></i> <span data-lang-key="socialTikTok">TikTok</span>
-            </a>
-            
-            <a href="https://www.facebook.com/ManlyFoods" class="social-btn facebook-btn" target="_blank">
-                <i class="fab fa-facebook-f"></i> <span data-lang-key="socialFacebook">Facebook</span>
-            </a>
-            
-            <a href="https://www.linkedin.com/company/95019223/" class="social-btn linkedin-btn" target="_blank">
-                <i class="fab fa-linkedin-in"></i> <span data-lang-key="socialLinkedIn">LinkedIn</span>
-            </a>
-            
-            <a href="mailto:sales@manlyfoods.com" class="social-btn email-btn">
-                <i class="fas fa-envelope"></i> <span data-lang-key="socialEmailUs">Email Us</span>
- <a href="mailto:sales@manlyfoods.com" class="social-btn email-btn">
-                <i class="fas fa-envelope"></i> <span data-lang-key="socialEmailUs">Email Us</span>
-            </a>
+        <div class="social-section">
+            <h3 data-lang-key="followUsTitle">Follow Us</h3>
+            <div class="social-media-container">
+                <a href="https://instagram.com/manlyfoodssg" class="social-btn instagram-btn" target="_blank">
+                    <i class="fab fa-instagram"></i> <span data-lang-key="socialManlyFoods">MANLY FOODS IG</span>
+                </a>
+                <a href="https://www.facebook.com/ManlyFoods" class="social-btn facebook-btn" target="_blank">
+                    <i class="fab fa-facebook-f"></i> <span data-lang-key="socialFacebook">Facebook</span>
+                </a>
+                <a href="https://www.instagram.com/ahmadteasg/" class="social-btn ahmadtea-btn" target="_blank">
+                    <i class="fab fa-instagram"></i> <span data-lang-key="socialAhmadTeaIG">Ahmad Tea IG</span>
+                </a>
+                <a href="https://www.facebook.com/ahmadteasg" class="social-btn facebook-btn" target="_blank">
+                    <i class="fab fa-facebook-f"></i> <span data-lang-key="socialAhmadTeaFB">Ahmad Tea FB</span>
+                </a>
+                <a href="https://www.tiktok.com/@manlyfoods" class="social-btn tiktok-btn" target="_blank">
+                    <i class="fab fa-tiktok"></i> <span data-lang-key="socialTikTok">TikTok</span>
+                </a>
+            </div>
+        </div>
+        <div class="social-section">
+            <h3 data-lang-key="shopWithUsTitle">Shop With Us</h3>
+            <div class="social-media-container">
+                <a href="https://www.tiktok.com/@manlyfoods" class="social-btn tiktok-btn" target="_blank">
+                    <i class="fab fa-tiktok"></i> <span data-lang-key="socialTikTokShop">TikTok Shop</span>
+                </a>
+                <a href="https://shopee.sg/shop/62656629" class="social-btn shopee-btn" target="_blank">
+                    <i class="fas fa-shopping-bag"></i> <span data-lang-key="socialShopee">Shopee</span>
+                </a>
+                <a href="https://www.lazada.sg/shop/manly-food1627632387" class="social-btn lazada-btn" target="_blank">
+                    <img src="https://img.icons8.com/color/48/000000/lazada.png" alt="Lazada Icon"> <span data-lang-key="socialLazada">Lazada</span>
+                </a>
+            </div>
         </div>
     </div>
 
@@ -2069,13 +2064,16 @@
 
 
                 // Social Media Bar
-                socialWhatsapp: "WhatsApp",
+                followUsTitle: "Follow Us Online",
+                shopWithUsTitle: "Shop With Us",
+                socialManlyFoods: "MANLY FOODS IG",
+                socialFacebook: "Facebook",
+                socialAhmadTeaIG: "Ahmad Tea IG",
+                socialAhmadTeaFB: "Ahmad Tea FB",
+                socialTikTok: "TikTok",
+                socialTikTokShop: "TikTok Shop",
                 socialShopee: "Shopee",
                 socialLazada: "Lazada",
-                socialManlyFoods: "MANLY FOODS IG",
-                socialAhmadTea: "Ahmad Tea IG",
-                socialTikTok: "TikTok",
-                socialFacebook: "Facebook",
                 socialLinkedIn: "LinkedIn",
                 socialEmailUs: "Email Us",
 
@@ -2247,13 +2245,16 @@
                 carouselSubtitle6: "连接优质品牌与本地市场",
 
                 // Social Media Bar
-                socialWhatsapp: "WhatsApp",
+                followUsTitle: "在线关注我们",
+                shopWithUsTitle: "在以下平台购物",
+                socialManlyFoods: "万利食品 IG",
+                socialFacebook: "脸书",
+                socialAhmadTeaIG: "Ahmad 茶 IG",
+                socialAhmadTeaFB: "Ahmad 茶 FB",
+                socialTikTok: "抖音",
+                socialTikTokShop: "TikTok 商城",
                 socialShopee: "虾皮",
                 socialLazada: "来赞达",
-                socialManlyFoods: "万利食品 IG",
-                socialAhmadTea: "Ahmad 茶 IG",
-                socialTikTok: "抖音",
-                socialFacebook: "脸书",
                 socialLinkedIn: "领英",
                 socialEmailUs: "发送邮件",
 
@@ -2396,13 +2397,13 @@
 
         // Hero Carousel Titles and Subtitles (language-dependent)
 const carouselTitles = {
-    en: "Premium Halal-Certified Food Distributor",
-    zh: "优质清真认证食品分销商"
+    en: "Trusted Singapore Food Wholesaler",
+    zh: "新加坡受信任的食品批发商"
 };
 
 const carouselSubtitles = {
-    en: "Trusted for Quality & Excellence Since 1986",
-    zh: "自1986年以来，品质卓越，值得信赖"
+    en: "Since 1986",
+    zh: "自1986年起"
 };
 
         // Function to set language

--- a/style.css
+++ b/style.css
@@ -224,7 +224,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background-color: rgba(0, 0, 0, 0.6);
+            background-color: rgba(80, 80, 80, 0.5); /* gray overlay */
             z-index: 1;
         }
 


### PR DESCRIPTION
## Summary
- simplify hero copy for a single static slide
- grey overlay for hero image
- restructure social media bar into follow and shop sections
- add translation keys for new social links

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68404f1e3000832182dafd2df129ba71