### PR TITLE
Fix client section and adjust theme color

### DIFF
--- a/index.html
+++ b/index.html
@@ -1680,7 +1680,7 @@
         <div class="container">
             <h2 class="section-title" data-lang-key="clientsTitle">We Supply To Key Clients</h2>
             <div class="clients-image-container">
-                <img src="carousel6.png" alt="Our Key Clients" class="clients-image" onerror="this.onerror=null;this.src='https://placehold.co/900x300/f0f0f0/333333?text=Client+Logos+Here';">
+                <img src="client.jpg" alt="Our Key Clients" class="clients-image" onerror="this.onerror=null;this.src='https://placehold.co/900x300/f0f0f0/333333?text=Client+Logos+Here';">
             </div>
         </div>
     </section>
@@ -1723,19 +1723,6 @@
                         <p class="testimonial-role" data-lang-key="testimonial4Role">E-commerce Entrepreneur</p>
                     </div>
                 </div>
-            </div>
-        </div>
-
-
-    <section class="section clients-section" id="clients">
-        <div class="container">
-            <h2 class="section-title" data-lang-key="clientsTitle">We Supply To Key Clients</h2>
-            <div class="clients-image-container">
-
-                <img src="client-image" alt="Our Key Clients" class="clients-image" onerror="this.onerror=null;this.src='https://placehold.co/900x300/f0f0f0/333333?text=Client+Logos+Here';">
-=======
-                <!-- TODO: image missing <img src="client-image" alt="Our Key Clients" class="clients-image" onerror="this.onerror=null;this.src='https://placehold.co/900x300/f0f0f0/333333?text=Client+Logos+Here';"> -->
-
             </div>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@
             --primary-wood-dark: #5A4A3C; /* 深木棕色，用于头部、底部、按钮等 */
             --primary-wood-medium: #8D7B6A; /* 中等木棕色 */
             --primary-wood-light: #F5E8D7; /* 米白色，主背景色 */
-            --accent-gold: #D4AF37; /* 金色，强调色 */
+            --accent-gold: rgba(135, 206, 235, 0.5); /* 金色，强调色 */
             --text-dark: #333333; /* 深色文本 */
             --text-light: #f8f8f8; /* 浅色文本 */
             --card-bg: rgba(255, 255, 255, 0.85); /* 卡片背景，半透明白色 */


### PR DESCRIPTION
## Summary
- remove leftover duplicate `clients` section
- point clients section image to `client.jpg`
- switch accent color to semi-transparent sky blue

## Testing
- `python3 check_images.py`

------
https://chatgpt.com/codex/tasks/task_e_6841505010808321848fe7920a4d9b40